### PR TITLE
PR - fix(contact): surface FormSubmit activation state + log provider responses

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -61,17 +61,27 @@ async function handleContact(request, env) {
   });
 
   if (!result.ok) {
+    // Log the raw provider response so CF Workers observability captures
+    // it — crucial when diagnosing FormSubmit activation / rate-limit /
+    // spam-filter states. The full `result` object stays server-side.
+    console.log('FormSubmit failure:', JSON.stringify({
+      httpStatus: result.httpStatus,
+      providerSuccess: result.providerSuccess,
+      providerMessage: result.providerMessage
+    }));
+
     const providerMessage = (result.providerMessage || '').toLowerCase();
-    const needsActivation = providerMessage.includes('needs activation');
+    const needsActivation = providerMessage.includes('activation');
 
     if (needsActivation) {
       return jsonResponse({
-        error: 'Contact form setup is pending activation. Please email hello@bytestreams.ai for now.'
+        error: "Contact form setup is pending activation. An activation email was sent to hello@bytestreams.ai — please click the link in it, then resubmit."
       }, 503);
     }
 
     return jsonResponse({
-      error: 'Message delivery failed. Please try again shortly.'
+      error: 'Message delivery failed. Please try again shortly.',
+      providerMessage: result.providerMessage || null
     }, 502);
   }
 
@@ -112,6 +122,8 @@ async function forwardToFormSubmit({ destinationEmail, siteName, name, email, me
 
   return {
     ok: response.ok && providerSuccess,
+    httpStatus: response.status,
+    providerSuccess,
     providerMessage: payload && payload.message ? String(payload.message) : ''
   };
 }

--- a/worker.js
+++ b/worker.js
@@ -71,7 +71,10 @@ async function handleContact(request, env) {
     }));
 
     const providerMessage = (result.providerMessage || '').toLowerCase();
-    const needsActivation = providerMessage.includes('activation');
+    // Narrow match: "activation" present AND "deactivat" absent, so
+    // messages about deactivation/deactivated accounts don't get
+    // misrouted into the activation-specific 503.
+    const needsActivation = providerMessage.includes('activation') && !providerMessage.includes('deactivat');
 
     if (needsActivation) {
       return jsonResponse({
@@ -79,9 +82,11 @@ async function handleContact(request, env) {
       }, 503);
     }
 
+    // Provider message stays server-side in the console.log above;
+    // never echo it to the client (may contain rate-limit reasons,
+    // spam verdicts, or other operational detail).
     return jsonResponse({
-      error: 'Message delivery failed. Please try again shortly.',
-      providerMessage: result.providerMessage || null
+      error: 'Message delivery failed. Please try again shortly.'
     }, 502);
   }
 


### PR DESCRIPTION
fix(email)fix work config to align with cloudflare so email will work

Closes #2

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Cloudflare Workers observability logging for FormSubmit failures (surfacing `httpStatus`, `providerSuccess`, and `providerMessage` server-side), tightens the activation keyword match with a `deactivat` exclusion to avoid misrouting deactivation messages, and removes the previously-flagged `providerMessage` leak from client-facing 502 responses.

- **Misleading activation 503 message (P1):** The new user-facing error tells the form visitor to "click the link" in the activation email — but that email is delivered to the site owner's inbox (`hello@bytestreams.ai`), not the visitor's. This is an instruction that end users literally cannot follow and should be reworded to direct the site owner to act.

<h3>Confidence Score: 3/5</h3>

One P1 UX defect remains: the activation error message directs form visitors to take an action only the site owner can perform.

Both previously-flagged security/logic issues are resolved (no providerMessage in 502 response, narrowed activation match). However the new 503 message body instructs the wrong party — a real user-facing bug on the active error path.

worker.js — line 81 activation error message copy

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | Adds CF Workers observability logging on FormSubmit failures and exposes httpStatus/providerSuccess in the return struct; fixes overly-broad activation keyword with a deactivat exclusion; one issue remains — the 503 activation message wrongly tells the end user to click a link in an email they don't have access to. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker.js
Line: 81

Comment:
**Activation message instructs the wrong party**

The 503 body tells whoever submitted the contact form to "please click the link in it, then resubmit." The FormSubmit activation email is sent to the *form owner's* inbox (`hello@bytestreams.ai`), not to the site visitor who triggered the 503. Regular visitors have no access to that inbox and cannot act on this instruction. The message should explain that the site owner needs to activate the form, not imply the submitter should click anything.

```suggestion
        error: "Contact form setup is pending — the site owner needs to activate it before messages can be sent. Please reach out directly at hello@bytestreams.ai for now."
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(contact): address review comments on..."](https://github.com/bytes0211/dialtone_menu/commit/f1b98623808e57f8c0a7c149d3b4e9621cff806b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29456743)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->