### PR TITLE
PR - Normalize missing asset routes to 404 instead of 500

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -3,6 +3,7 @@
 wrangler.toml
 .assetsignore
 worker.js
+robots.txt
 package.json
 package-lock.json
 pnpm-lock.yaml

--- a/developer/bytestreams-robots.txt
+++ b/developer/bytestreams-robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Allow: /
+Disallow: /admin/
+Disallow: /api/
+
+User-agent: GPTBot
+Disallow: /
+
+Sitemap: https://bytestreams.ai/sitemap.xml

--- a/developer/developer-journal.md
+++ b/developer/developer-journal.md
@@ -1,0 +1,20 @@
+# Developer Journal
+
+## 2026-04-23
+- Added `robots.txt` at project root using the requested policy pattern.
+- Allowed general crawling except `/admin/` and `/api/`.
+- Blocked `GPTBot` completely.
+- Added sitemap references for both DialTone and ByteStreams:
+  - `https://dialtone.menu/sitemap.xml`
+  - `https://bytestreams.ai/sitemap.xml`
+- Added a ByteStreams-only robots template at `developer/bytestreams-robots.txt` for host-specific deployment on bytestreams.ai.
+- Moved robots handling into `worker.js` via an explicit `/robots.txt` route so robots policy is no longer managed as a static asset.
+- Route now emits host-specific sitemap values (`dialtone.menu` vs `bytestreams.ai`) and keeps `GPTBot` blocked.
+- Added a lightweight Node test at `tests/robots.test.mjs` with `pnpm run test:robots` to validate:
+  - DialTone host emits DialTone sitemap
+  - ByteStreams host emits ByteStreams sitemap
+  - `GPTBot` remains blocked
+  - Non-robots paths still fall through to `env.ASSETS.fetch`
+- Fixed routing bug where missing static paths could surface as 500.
+- Worker now normalizes unmatched lookup failures to HTTP 404 for `GET`/`HEAD` when assets lookup throws or returns 500.
+- Extended tests to cover missing-path cases like `/robot.txt` and `/favicon.ico` so regressions are caught quickly.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "dialtone-menu",
   "private": true,
+  "type": "module",
   "version": "0.1.0",
   "description": "DialTone marketing site — dialtone.menu (Cloudflare Workers with Static Assets)",
   "scripts": {
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test:robots": "node tests/robots.test.mjs"
   },
   "devDependencies": {
     "wrangler": "4.83.0"

--- a/tests/robots.test.mjs
+++ b/tests/robots.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import worker from '../worker.js';
+
+async function getRobots(hostname) {
+  const request = new Request(`https://${hostname}/robots.txt`);
+  const env = {
+    ASSETS: {
+      fetch: async () => new Response('asset response', { status: 200 })
+    }
+  };
+
+  return worker.fetch(request, env);
+}
+
+async function run() {
+  const dialtoneResponse = await getRobots('dialtone.menu');
+  const dialtoneText = await dialtoneResponse.text();
+
+  assert.equal(dialtoneResponse.status, 200, 'DialTone robots should return 200');
+  assert.match(
+    dialtoneResponse.headers.get('content-type') || '',
+    /^text\/plain/i,
+    'DialTone robots should return text/plain content type'
+  );
+  assert.match(
+    dialtoneText,
+    /Sitemap: https:\/\/dialtone\.menu\/sitemap\.xml/,
+    'DialTone host should emit DialTone sitemap'
+  );
+  assert.doesNotMatch(
+    dialtoneText,
+    /Sitemap: https:\/\/bytestreams\.ai\/sitemap\.xml/,
+    'DialTone host should not emit ByteStreams sitemap'
+  );
+  assert.match(dialtoneText, /User-agent: GPTBot\nDisallow: \//, 'GPTBot should be blocked');
+
+  const bytestreamsResponse = await getRobots('www.bytestreams.ai');
+  const bytestreamsText = await bytestreamsResponse.text();
+
+  assert.equal(bytestreamsResponse.status, 200, 'ByteStreams robots should return 200');
+  assert.match(
+    bytestreamsText,
+    /Sitemap: https:\/\/bytestreams\.ai\/sitemap\.xml/,
+    'ByteStreams host should emit ByteStreams sitemap'
+  );
+  assert.doesNotMatch(
+    bytestreamsText,
+    /Sitemap: https:\/\/dialtone\.menu\/sitemap\.xml/,
+    'ByteStreams host should not emit DialTone sitemap'
+  );
+
+  let assetsFallbackCalled = false;
+  const fallbackRequest = new Request('https://dialtone.menu/');
+  const fallbackEnv = {
+    ASSETS: {
+      fetch: async () => {
+        assetsFallbackCalled = true;
+        return new Response('asset ok', { status: 200 });
+      }
+    }
+  };
+
+  const fallbackResponse = await worker.fetch(fallbackRequest, fallbackEnv);
+  assert.equal(fallbackResponse.status, 200, 'Non-robots path should return asset response status');
+  assert.equal(assetsFallbackCalled, true, 'Non-robots path should delegate to env.ASSETS.fetch');
+
+  const missingPathRequest = new Request('https://dialtone.menu/robot.txt');
+  const throwingAssetsEnv = {
+    ASSETS: {
+      fetch: async () => {
+        throw new Error('No such object in asset manifest');
+      }
+    }
+  };
+
+  const missingPathResponse = await worker.fetch(missingPathRequest, throwingAssetsEnv);
+  assert.equal(missingPathResponse.status, 404, 'Missing asset lookups should return 404 when assets fetch throws');
+  assert.equal(await missingPathResponse.text(), 'Not Found', '404 body should be stable for missing paths');
+
+  const missingFaviconRequest = new Request('https://dialtone.menu/favicon.ico');
+  const fiveHundredAssetsEnv = {
+    ASSETS: {
+      fetch: async () => new Response('internal', { status: 500 })
+    }
+  };
+
+  const missingFaviconResponse = await worker.fetch(missingFaviconRequest, fiveHundredAssetsEnv);
+  assert.equal(
+    missingFaviconResponse.status,
+    404,
+    'Missing favicon should return 404 when assets binding reports 500 for lookup'
+  );
+
+  console.log('robots route tests passed');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/worker.js
+++ b/worker.js
@@ -6,13 +6,80 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
+    if (url.pathname === '/robots.txt') {
+      return handleRobots(url);
+    }
+
     if (url.pathname === '/api/contact') {
       return handleContact(request, env);
     }
 
-    return env.ASSETS.fetch(request);
+    return handleAssetRequest(request, env);
   }
 };
+
+async function handleAssetRequest(request, env) {
+  try {
+    const response = await env.ASSETS.fetch(request);
+
+    // Missing static assets can surface as 500 from the assets binding;
+    // normalize those to 404 so crawlers and clients get the correct status.
+    if (response.status === 500 && isLookupMethod(request.method)) {
+      return notFoundResponse();
+    }
+
+    return response;
+  } catch (error) {
+    // If asset resolution throws on an unmatched path, return 404 rather
+    // than exposing an internal failure.
+    if (isLookupMethod(request.method)) {
+      console.log('ASSETS fetch lookup error:', String(error));
+      return notFoundResponse();
+    }
+
+    throw error;
+  }
+}
+
+function isLookupMethod(method) {
+  return method === 'GET' || method === 'HEAD';
+}
+
+function notFoundResponse() {
+  return new Response('Not Found', {
+    status: 404,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+function handleRobots(url) {
+  const host = url.hostname.toLowerCase();
+  const isByteStreamsHost = host === 'bytestreams.ai' || host === 'www.bytestreams.ai';
+  const sitemap = isByteStreamsHost
+    ? 'https://bytestreams.ai/sitemap.xml'
+    : 'https://dialtone.menu/sitemap.xml';
+
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /admin/',
+    'Disallow: /api/',
+    '',
+    'User-agent: GPTBot',
+    'Disallow: /',
+    '',
+    `Sitemap: ${sitemap}`,
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
 
 async function handleContact(request, env) {
   if (request.method !== 'POST') {


### PR DESCRIPTION
chore(app) add robot file

Closes #4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `robots.txt` handling from static assets into the worker, enabling host-aware sitemap selection (`dialtone.menu` vs `bytestreams.ai`) and blocking `GPTBot`. It also wraps `env.ASSETS.fetch` to normalise 500 responses and thrown errors to 404 for `GET`/`HEAD` requests, preventing missing-asset paths from surfacing as server errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no blocking issues.

The logic is correct and well-tested. The only finding is a minor console.log vs console.error nit that does not affect runtime behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | Adds explicit /robots.txt route with host-based sitemap selection, wraps ASSETS.fetch to normalise 500s and thrown errors to 404 for GET/HEAD — logic is sound, one minor console.log vs console.error nit. |
| tests/robots.test.mjs | Adds lightweight Node test covering DialTone and ByteStreams host routing, GPTBot blocking, asset fallthrough, and 404 normalisation for both thrown errors and 500 responses. |
| .assetsignore | robots.txt added to the ignore list so Cloudflare does not deploy it as a static asset; consistent with the new dynamic worker route. |
| developer/bytestreams-robots.txt | Standalone ByteStreams robots template for reference/manual deployment; not served by the worker directly. |
| package.json | Adds "type": "module" (required for .mjs test import of worker.js as ESM) and the test:robots script. |
| developer/developer-journal.md | New developer journal entry documenting the robots route and 404-normalization changes. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker.js
Line: 43

Comment:
**`console.log` used for error logging**

Error-level events should use `console.error` so they are correctly classified in Cloudflare's log streams and any log-aggregation tooling that distinguishes severity levels.

```suggestion
      console.error('ASSETS fetch lookup error:', String(error));
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(app) add robot file"](https://github.com/bytes0211/dialtone_menu/commit/6ac73c82b9b11b1eda3abeb1e120689669a72a68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29511493)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->