### PR TITLE
feat(orders): add Stripe Checkout post-payment landing pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,28 @@
 - Keep `/api/contact` IP rate limiting in place using `CF-Connecting-IP` before DB/email calls.
 - Keep secrets out of git (`.env.supabase`, `supabase/.temp/`); rotate immediately if exposure is suspected.
 - Preserve CI deploy secret checks (`RESEND_API_KEY` and at least one Supabase DB key).
+
+## DialTone Stripe Checkout integration (shipped May 2, 2026)
+
+This site is the configured landing target for **post-payment redirects** from Stripe Checkout sessions created by the DialTone product (sibling repo at `~/dev/projects/dialtone/`). When a customer pays for an order via SMS link, Stripe redirects them here.
+
+**Two routes:**
+
+| Route | Triggered when | Static template |
+|---|---|---|
+| `/orders/:id/paid` | Stripe Checkout `success_url` — payment succeeded | `public/orders/paid.html` |
+| `/orders/:id/cancel` | Stripe Checkout `cancel_url` — customer clicked back/cancel | `public/orders/cancel.html` |
+
+**How the routing works:** `worker.js` matches `/^\/orders\/[^/]+\/(paid|cancel)$/` for GET/HEAD requests and rewrites the URL pathname to the corresponding static template before delegating to `env.ASSETS.fetch`. The `:id` UUID in the URL is opaque (it belongs to DialTone's separate Supabase project; this repo has no DB access) — pages do not read or display it. Coverage in `tests/orders.test.mjs`.
+
+**Implementation rules to preserve:**
+- Pages MUST stay static — do not add fetch calls, do not try to look up order details. The `:id` param exists only to make the URL appear order-specific to the customer; it has no functional use here.
+- `<meta name="robots" content="noindex, nofollow">` on both pages keeps them out of search indexes (transactional URLs aren't useful to crawl).
+- Stripe Checkout has only `success_url` and `cancel_url` redirects — there is **no `failure_url`**. Failed payment attempts (declined card, etc.) keep the customer on Stripe's hosted checkout for retry; they only land here on a successful payment OR a voluntary cancel.
+- Don't add these URLs to `sitemap.xml` — the sitemap handler in `worker.js` deliberately omits them.
+
+**Where the redirect URL is configured (sibling repo):**
+- `~/dev/projects/dialtone/supabase/functions/admin_create_manual_order/index.ts` builds `success_url = ${DIALTONE_PUBLIC_BASE_URL}/orders/${orderId}/paid` and `cancel_url` similarly.
+- Default `DIALTONE_PUBLIC_BASE_URL` is `https://dialtone.menu` (this site). Set explicitly in the sibling repo's cloud Supabase secrets before going to a real paying customer to lock the value in.
+
+See sibling repo's `developer/m8-live-demo-checklist.md` "Lessons learned" section for the full M8 deploy context.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "validate:deploy": "node developer/ci/validate-cloudflare-config.mjs",
     "deploy": "wrangler deploy",
-    "test:robots": "node tests/robots.test.mjs"
+    "test:robots": "node tests/robots.test.mjs",
+    "test:orders": "node tests/orders.test.mjs"
   },
   "devDependencies": {
     "wrangler": "4.85.0"

--- a/public/orders/cancel.html
+++ b/public/orders/cancel.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Checkout cancelled — DialTone</title>
+  <meta name="description" content="Your checkout was cancelled. No payment was processed." />
+  <meta name="robots" content="noindex, nofollow" />
+
+  <link rel="icon" type="image/svg+xml" href="/images/favicon.svg?v=20260427" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;900&family=DM+Sans:wght@400;500;700&display=swap" />
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    :root {
+      --navy: #06234B;
+      --gold: #E8A020;
+      --cream: #FAF7F2;
+      --text: #1A1A2E;
+      --muted: #6B7280;
+      --line: rgba(6, 35, 75, 0.12);
+      --font-display: 'Playfair Display', Georgia, serif;
+      --font-body: 'DM Sans', 'Segoe UI', -apple-system, sans-serif;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--cream);
+      color: var(--text);
+      font-family: var(--font-body);
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1.5rem;
+    }
+
+    .logo {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.5rem;
+      color: var(--navy);
+      text-decoration: none;
+      margin-bottom: 2.5rem;
+      letter-spacing: -0.01em;
+    }
+
+    .logo span { color: var(--gold); }
+
+    .card {
+      max-width: 480px;
+      width: 100%;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 2.5rem 2rem;
+      text-align: center;
+      box-shadow: 0 1px 2px rgba(6, 35, 75, 0.04);
+    }
+
+    .icon {
+      width: 56px;
+      height: 56px;
+      margin: 0 auto 1.5rem;
+      border-radius: 50%;
+      background: rgba(6, 35, 75, 0.08);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--navy);
+      font-size: 28px;
+      font-weight: 400;
+      line-height: 1;
+    }
+
+    h1 {
+      font-family: var(--font-display);
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--navy);
+      margin: 0 0 0.75rem;
+      letter-spacing: -0.01em;
+    }
+
+    .lede {
+      color: var(--muted);
+      margin: 0 0 1.5rem;
+    }
+
+    .footer-note {
+      font-size: 0.9rem;
+      color: var(--text);
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="logo">Dial<span>Tone</span></a>
+
+  <main class="card">
+    <div class="icon" aria-hidden="true">&times;</div>
+    <h1>Checkout cancelled</h1>
+    <p class="lede">No payment was processed.</p>
+    <p class="footer-note">If you'd still like to place this order, please contact the restaurant directly.</p>
+  </main>
+</body>
+</html>

--- a/public/orders/paid.html
+++ b/public/orders/paid.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Payment received — DialTone</title>
+  <meta name="description" content="Your order is in the queue. You'll get an SMS when it's being prepared." />
+  <meta name="robots" content="noindex, nofollow" />
+
+  <link rel="icon" type="image/svg+xml" href="/images/favicon.svg?v=20260427" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;900&family=DM+Sans:wght@400;500;700&display=swap" />
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    :root {
+      --navy: #06234B;
+      --gold: #E8A020;
+      --green: #1f8a4d;
+      --cream: #FAF7F2;
+      --text: #1A1A2E;
+      --muted: #6B7280;
+      --line: rgba(6, 35, 75, 0.12);
+      --font-display: 'Playfair Display', Georgia, serif;
+      --font-body: 'DM Sans', 'Segoe UI', -apple-system, sans-serif;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--cream);
+      color: var(--text);
+      font-family: var(--font-body);
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1.5rem;
+    }
+
+    .logo {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.5rem;
+      color: var(--navy);
+      text-decoration: none;
+      margin-bottom: 2.5rem;
+      letter-spacing: -0.01em;
+    }
+
+    .logo span { color: var(--gold); }
+
+    .card {
+      max-width: 480px;
+      width: 100%;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 2.5rem 2rem;
+      text-align: center;
+      box-shadow: 0 1px 2px rgba(6, 35, 75, 0.04);
+    }
+
+    .check {
+      width: 56px;
+      height: 56px;
+      margin: 0 auto 1.5rem;
+      border-radius: 50%;
+      background: var(--green);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 28px;
+      font-weight: 700;
+      line-height: 1;
+    }
+
+    h1 {
+      font-family: var(--font-display);
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--navy);
+      margin: 0 0 0.75rem;
+      letter-spacing: -0.01em;
+    }
+
+    .lede {
+      color: var(--muted);
+      margin: 0 0 1.5rem;
+    }
+
+    .next {
+      text-align: left;
+      background: #faf6ec;
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      margin: 0 0 1.5rem;
+    }
+
+    .next-title {
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--gold);
+      font-weight: 700;
+      margin: 0 0 0.5rem;
+    }
+
+    .next ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      font-size: 0.95rem;
+    }
+
+    .next li {
+      padding: 0.25rem 0;
+      color: var(--text);
+    }
+
+    .footer-note {
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="logo">Dial<span>Tone</span></a>
+
+  <main class="card">
+    <div class="check" aria-hidden="true">&#10003;</div>
+    <h1>Payment received</h1>
+    <p class="lede">Thanks &mdash; your order is in the queue.</p>
+
+    <div class="next">
+      <p class="next-title">What happens next</p>
+      <ul>
+        <li>You'll get an SMS when your order is being prepared.</li>
+        <li>Another when it's ready for pickup.</li>
+      </ul>
+    </div>
+
+    <p class="footer-note">If you have questions, contact the restaurant directly.</p>
+  </main>
+</body>
+</html>

--- a/tests/orders.test.mjs
+++ b/tests/orders.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import worker from '../worker.js';
+
+/**
+ * Captures the Request URL that env.ASSETS.fetch is called with so we
+ * can verify the Worker rewrote the dynamic /orders/:id/{paid,cancel}
+ * path to the static template path before delegating to assets.
+ */
+function makeAssetsRecorder(responseStatus = 200) {
+  const calls = [];
+  return {
+    calls,
+    fetch: async (req) => {
+      calls.push(new URL(req.url).pathname);
+      return new Response('asset ok', { status: responseStatus });
+    },
+  };
+}
+
+async function run() {
+  // /orders/:id/paid → /orders/paid.html
+  {
+    const env = { ASSETS: makeAssetsRecorder() };
+    const res = await worker.fetch(
+      new Request('https://dialtone.menu/orders/abc-123-uuid-here/paid'),
+      env,
+    );
+    assert.equal(res.status, 200, 'paid route should return 200');
+    assert.deepEqual(
+      env.ASSETS.calls,
+      ['/orders/paid.html'],
+      'paid route must rewrite to the static template path',
+    );
+  }
+
+  // /orders/:id/cancel → /orders/cancel.html
+  {
+    const env = { ASSETS: makeAssetsRecorder() };
+    const res = await worker.fetch(
+      new Request('https://dialtone.menu/orders/941926c4-de9b-4fdf-a737-08b6c9a9d46e/cancel'),
+      env,
+    );
+    assert.equal(res.status, 200, 'cancel route should return 200');
+    assert.deepEqual(
+      env.ASSETS.calls,
+      ['/orders/cancel.html'],
+      'cancel route must rewrite to the static template path',
+    );
+  }
+
+  // Non-matching /orders/* paths should fall through to ASSETS unchanged.
+  {
+    const env = { ASSETS: makeAssetsRecorder() };
+    const res = await worker.fetch(
+      new Request('https://dialtone.menu/orders/foo/bar'),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(
+      env.ASSETS.calls,
+      ['/orders/foo/bar'],
+      'non-matching orders paths must NOT be rewritten',
+    );
+  }
+
+  // POST to /orders/:id/paid should fall through to assets (only GET/HEAD
+  // hit the rewrite branch — Stripe redirects via GET).
+  {
+    const env = { ASSETS: makeAssetsRecorder() };
+    const res = await worker.fetch(
+      new Request('https://dialtone.menu/orders/abc/paid', { method: 'POST' }),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(
+      env.ASSETS.calls,
+      ['/orders/abc/paid'],
+      'POST to order-result paths must NOT be rewritten (only GET/HEAD)',
+    );
+  }
+
+  console.log('orders route tests passed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/worker.js
+++ b/worker.js
@@ -48,9 +48,38 @@ async function routeRequest(request, env, url) {
     return handleContact(request, env);
   }
 
+  // DialTone Stripe Checkout post-payment landing pages.
+  // Stripe redirects paying customers to /orders/<order_id>/paid or
+  // /orders/<order_id>/cancel after a Checkout Session completes; the
+  // order_id in the URL is opaque (a UUID from the sibling DialTone
+  // Supabase project, not accessible from this site). We just rewrite
+  // the path to a static template and serve via the assets binding.
+  // See AGENTS.md → "DialTone Stripe Checkout integration" for context.
+  const orderResultMatch = url.pathname.match(/^\/orders\/[^/]+\/(paid|cancel)$/);
+  if (orderResultMatch && isLookupMethod(request.method)) {
+    return handleOrderResult(request, env, url, orderResultMatch[1]);
+  }
+
   // For all paths not explicitly handled above, delegate to the assets binding
   // and normalize missing lookups to 404.
   return handleAssetRequest(request, env);
+}
+
+async function handleOrderResult(request, env, url, kind) {
+  const targetUrl = new URL(url);
+  targetUrl.pathname = `/orders/${kind}.html`;
+  targetUrl.search = '';
+  const rewritten = new Request(targetUrl.toString(), request);
+  try {
+    const response = await env.ASSETS.fetch(rewritten);
+    if (response.status === 500 && isLookupMethod(request.method)) {
+      return notFoundResponse();
+    }
+    return response;
+  } catch (error) {
+    console.log('ASSETS order-result lookup error:', String(error));
+    return notFoundResponse();
+  }
 }
 
 async function handleAssetRequest(request, env) {


### PR DESCRIPTION
## Summary

DialTone (sibling repo at `~/dev/projects/dialtone/`) creates Stripe Checkout sessions with `success_url=https://dialtone.menu/orders/<id>/paid` and `cancel_url=https://dialtone.menu/orders/<id>/cancel`. Both routes were 404'ing — paying customers landed on the marketing 404 page after a successful payment, despite the order itself flipping to `paid` correctly via webhook (server-to-server, independent of this redirect).

This PR adds the two static landing pages + a Worker route handler that rewrites `/orders/:id/{paid,cancel}` → `/orders/{paid,cancel}.html` and serves via `env.ASSETS`. The `:id` UUID is opaque and not displayed (it lives in DialTone's separate Supabase project; this site has no DB access to it).

## Files

- `public/orders/paid.html` — "Payment received" thank-you with next-steps copy. Branded with the marketing site's existing palette + fonts. `noindex, nofollow`.
- `public/orders/cancel.html` — Neutral "Checkout cancelled" copy pointing to the restaurant for retry. Same styling.
- `worker.js` — Matches `^/orders/[^/]+/(paid|cancel)$` for GET/HEAD only (Stripe redirects via GET); rewrites the URL pathname before delegating to `env.ASSETS`.
- `tests/orders.test.mjs` — Coverage for the rewrite (paid + cancel), non-matching paths fall through unchanged, and POST/non-GET methods don't trigger the rewrite.
- `package.json` — New `test:orders` npm script.
- `AGENTS.md` — Existing "DialTone Stripe Checkout integration" section updated from "open work" to "shipped" with implementation notes future agents should preserve.

## Test plan

- [x] `pnpm validate:deploy` passes
- [x] `pnpm test:robots` still passes (no regression)
- [x] `pnpm test:orders` passes (new tests for the rewrite)
- [ ] After merge + deploy: place a fresh DialTone test order, complete payment with Stripe test card `4242 4242 4242 4242`, confirm landing on the new paid page (not the 404)
- [ ] Use Stripe dashboard to expire a Checkout session and confirm the cancel page appears if a customer hits cancel mid-checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap where paying customers landed on a 404 after completing a Stripe Checkout session by adding two static landing pages (`paid.html`, `cancel.html`) and a Worker rewrite rule that maps `/orders/:id/{paid,cancel}` → the corresponding static asset. The implementation is clean: pages are correctly marked `noindex, nofollow`, the order UUID is never read or rendered, and the rewrite is guarded to GET/HEAD only to match Stripe's redirect behaviour.

<h3>Confidence Score: 4/5</h3>

Safe to merge — one minor style nit, no logic or security issues.

All findings are P2. The only issue is a redundant `isLookupMethod` check inside `handleOrderResult` that can never affect behaviour since the function is only called after the same guard passes at the call site. No security concerns, no broken logic, tests cover the key paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | Adds `handleOrderResult` that rewrites `/orders/:id/{paid,cancel}` → static HTML via ASSETS; logic is correct but contains a redundant `isLookupMethod` guard inside the new function. |
| tests/orders.test.mjs | Good coverage: paid rewrite, cancel rewrite, non-matching fall-through, and POST bypass are all tested. |
| public/orders/paid.html | New static thank-you page; `noindex, nofollow` set, no dynamic content or order-ID display. |
| public/orders/cancel.html | New static cancellation page; `noindex, nofollow` set, neutral copy, consistent styling. |
| package.json | Adds `test:orders` script pointing to the new test file. |
| AGENTS.md | Documents the Stripe Checkout integration with routing rules, preservation constraints, and sibling-repo references. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker.js:75
**Redundant `isLookupMethod` guard inside `handleOrderResult`**

`handleOrderResult` is only reachable when `isLookupMethod(request.method)` is already `true` (line 59 gates it), so the same check on line 75 is always `true` and can never alter the branch. The catch block also differs from `handleAssetRequest` by never re-throwing for non-GET/HEAD, but that path is unreachable for the same reason. Both could silently confuse future readers into thinking the function can be called for non-lookup methods.

```suggestion
    if (response.status === 500) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(orders): add Stripe Checkout post-p..."](https://github.com/bytes0211/dialtone_menu/commit/dd881450f4e2e3d1033cb0e6a1820605d017a7f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30566113)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->